### PR TITLE
Improve thing-at-point definition for beancount-link

### DIFF
--- a/beancount-tests.el
+++ b/beancount-tests.el
@@ -303,3 +303,24 @@ known option nmaes."
                              ("2020" . 113)
                              ("2020 January" . 120)
                              ("2020 February" . 136)))))))
+
+(ert-deftest beancount/link-at-point-001 ()
+  :tags '(regress thing-at-point)
+  (with-temp-buffer
+    (insert "^link")
+    (beancount-mode)
+    (goto-char 2)
+    (should (equal (thing-at-point 'beancount-link) "^link"))))
+
+(ert-deftest beancount/link-at-point-002 ()
+  :tags '(regress thing-at-point)
+  (with-temp-buffer
+    (insert "not-a-link")
+    (should (equal (thing-at-point 'beancount-link) nil))))
+
+(ert-deftest beancount/link-at-point-003 ()
+  :tags '(regress thing-at-point)
+  (with-temp-buffer
+    (insert "foo ^link baz")
+    (goto-char 15)
+    (should (equal (thing-at-point 'beancount-link) "^link"))))

--- a/beancount.el
+++ b/beancount.el
@@ -842,11 +842,14 @@ Only useful if you have not installed Beancount properly in your PATH.")
                     (file-relative-name buffer-file-name)
                     (number-to-string (line-number-at-pos)))))
 
-;; Define a type for (thing-at-point) for Beancount links.
-(defvar beancount-link-chars "[:alnum:]-_\\.\\^"
-  "Characters allowable in Beancount links.")
+(defun beancount--bounds-of-link-at-point ()
+  ;; There is no length limit for links but it seems reasonable to
+  ;; limit the search for the link to the 128 characters before and
+  ;; after the point. This number is chosen arbitrarily.
+  (when (thing-at-point-looking-at (concat "\\^[" beancount-tag-chars "]+") 128)
+    (cons (match-beginning 0) (match-end 0))))
 
-(define-thing-chars beancount-link beancount-link-chars)
+(put 'beancount-link 'bounds-of-thing-at-point #'beancount--bounds-of-link-at-point)
 
 (defun beancount-linked ()
   "Get the \"linked\" info from `beancount-doctor-program'."


### PR DESCRIPTION
The new definition should better match links only. It also avoids the
use of a function that has been introduced in Emacs 27, restoring
compatibility of beancount-mode with Emacs 26.