### PR TITLE
Indentation and completion improvements

### DIFF
--- a/beancount-tests.el
+++ b/beancount-tests.el
@@ -1,6 +1,7 @@
 ;;; beancount-test.el --- ERT for beancount-mode -*- lexical-binding: t -*-
 
 ;; Copyright 2019 Daniele Nicolodi <daniele@grinta.net>
+;; Copyright 2019 Alex Smith <aes7mv@virginia.edu>
 
 ;; This file is not part of GNU Emacs.
 

--- a/beancount-tests.el
+++ b/beancount-tests.el
@@ -372,5 +372,5 @@ known option nmaes."
   :tags '(regress thing-at-point)
   (with-temp-buffer
     (insert "foo ^link baz")
-    (goto-char 15)
+    (goto-char 5)
     (should (equal (thing-at-point 'beancount-link) "^link"))))

--- a/beancount-tests.el
+++ b/beancount-tests.el
@@ -238,6 +238,57 @@ known option nmaes."
 "))
     (should (equal beancount-accounts '("Assets:Checking" "Expenses:Test")))))
 
+(ert-deftest beancount-completion-002 ()
+  :tags '(completion regress)
+  (with-temp-buffer
+    (insert "
+2019-01-01 ope Assets:Checking
+")
+    (beancount-mode)
+    (search-backward "p")
+    (completion-at-point)
+    (should (equal (buffer-string) "
+2019-01-01 open Assets:Checking
+"))))
+
+(ert-deftest beancount-completion-003 ()
+  :tags '(completion regress)
+  (with-temp-buffer
+    (insert "
+option \"operating_ \"USD\"
+")
+    (beancount-mode)
+    (search-backward "p")
+    (completion-at-point)
+    (should (equal (buffer-string) "
+option \"operating_currency\" \"USD\"
+"))))
+
+(ert-deftest beancount-completion-004 ()
+  :tags '(completion regress)
+  (with-temp-buffer
+    (insert "
+2019-01-01 * \"Example ^foo-something-link-like-in-string\" ^foo-link/_.etc ^bar-link #foo-tag.more_/cruft #bar-tag
+  Expenses:Test    1.00 USD
+  Assets:Checking
+
+2019-01-01 * \"Example\" ^f #b
+")
+    (beancount-mode)
+    (goto-char (point-max))
+    (search-backward "^f")
+    (completion-at-point)
+    (goto-char (point-max))
+    (search-backward "#b")
+    (completion-at-point)
+    (should (equal (buffer-string) "
+2019-01-01 * \"Example ^foo-something-link-like-in-string\" ^foo-link/_.etc ^bar-link #foo-tag.more_/cruft #bar-tag
+  Expenses:Test    1.00 USD
+  Assets:Checking
+
+2019-01-01 * \"Example\" ^foo-link/_.etc #bar-tag
+"))))
+
 (ert-deftest beancount/outline-001 ()
   :tags '(outline)
   (with-temp-buffer

--- a/beancount.el
+++ b/beancount.el
@@ -3,11 +3,13 @@
 ;; Copyright (C) 2013 Martin Blais <blais@furius.ca>
 ;; Copyright (C) 2015 Free Software Foundation, Inc.
 ;; Copyright (C) 2019 Daniele Nicolodi <daniele@grinta.net>
+;; Copyright (C) 2021 Alex Smith <aes7mv@virginia.edu>
 
 ;; Version: 0
 ;; Author: Martin Blais <blais@furius.ca>
 ;; Author: Stefan Monnier <monnier@iro.umontreal.ca>
 ;; Author: Daniele Nicolodi <daniele@grinta.net>
+;; Author: Alex Smith <aes7mv@virginia.edu>
 
 ;; This file is not part of GNU Emacs.
 

--- a/beancount.el
+++ b/beancount.el
@@ -49,6 +49,11 @@ and price directives. Set to 0 to automatically determine the
 minimum column that will allow to align all amounts."
   :type 'integer)
 
+(defcustom beancount-alignment-sep-minimum 2
+  "Minimum number of spaces used to separate an aligned number
+from the preceding syntax element."
+  :type 'integer)
+
 (defcustom beancount-highlight-transaction-at-point nil
   "If t highlight transaction under point."
   :type 'boolean)
@@ -617,7 +622,8 @@ will allow to align all numbers."
       ;; Align the number if we got its bounds above
       (when number-beginning
         (let* ((prev-end-column (- prev-end (line-beginning-position)))
-               (spaces (max 2 (- target-column prev-end-column number-width))))
+               (spaces (max beancount-alignment-sep-minimum
+                            (- target-column prev-end-column number-width))))
           (unless (eq spaces (- number-beginning prev-end))
             (goto-char prev-end)
             (delete-region prev-end number-beginning)
@@ -636,7 +642,8 @@ will allow to align all numbers."
       ;; Align the currency if we got its bounds above
       (when currency-beginning
         (let* ((prev-end-column (- prev-end (line-beginning-position)))
-               (spaces (max 2 (- target-column prev-end-column))))
+               (spaces (max beancount-alignment-sep-minimum
+                        (- target-column prev-end-column))))
           (unless (eq spaces (- currency-beginning prev-end))
             (goto-char prev-end)
             (delete-region prev-end currency-beginning)

--- a/beancount.el
+++ b/beancount.el
@@ -311,7 +311,8 @@ from the open directive for the relevant account."
 
 (defun beancount-tab-dwim (&optional arg)
   (interactive "P")
-  (if (and outline-minor-mode
+  (if (and (not (use-region-p))
+           outline-minor-mode
            (or arg (outline-on-heading-p)))
       (beancount-outline-cycle arg)
     (indent-for-tab-command)))

--- a/beancount.el
+++ b/beancount.el
@@ -54,6 +54,10 @@ minimum column that will allow to align all amounts."
 from the preceding syntax element."
   :type 'integer)
 
+(defcustom beancount-tab-dwim-indent-align-numbers nil
+  "If t align numbers when indenting via beancount-tab-dwim."
+  :type 'boolean)
+
 (defcustom beancount-highlight-transaction-at-point nil
   "If t highlight transaction under point."
   :type 'boolean)
@@ -655,7 +659,8 @@ will allow to align all numbers."
     (unless (eq indent (current-indentation))
       (if savep (save-excursion (indent-line-to indent))
         (indent-line-to indent)))
-    (unless (eq this-command 'beancount-tab-dwim)
+    (unless (and (eq this-command 'beancount-tab-dwim)
+                 (not beancount-tab-dwim-indent-align-numbers))
       (beancount-align-number (beancount-number-alignment-column))
       (beancount-align-currency (+ (beancount-number-alignment-column) 1)))))
 

--- a/beancount.el
+++ b/beancount.el
@@ -518,17 +518,6 @@ With an argument move to the next non cleared transaction."
           (setq beancount-accounts nil)
           (list (match-beginning 1) (match-end 1) #'beancount-account-completion-table))
 
-         ;; posting
-         ((and (beancount-looking-at
-                (concat "[ \t]+\\([" beancount-account-chars "]*\\)") 1 pos)
-               ;; Do not force the account name to start with a
-               ;; capital, so that it is possible to use substring
-               ;; completion and we can rely on completion to fix
-               ;; capitalization thanks to completion-ignore-case.
-               (beancount-inside-transaction-p))
-          (setq beancount-accounts nil)
-          (list (match-beginning 1) (match-end 1) #'beancount-account-completion-table))
-
          ;; tags
          ((save-excursion
             (goto-char pos)
@@ -555,7 +544,18 @@ With an argument move to the next non cleared transaction."
                         (setq candidates
                               (sort (beancount-collect regexp 0) #'string<)))
                     (complete-with-action action candidates string pred))))
-            (list (match-beginning 0) (match-end 0) completion-table))))))))
+            (list (match-beginning 0) (match-end 0) completion-table)))
+
+         ;; posting
+         ((and (beancount-looking-at
+                (concat "[ \t]+\\([" beancount-account-chars "]*\\)") 1 pos)
+               ;; Do not force the account name to start with a
+               ;; capital, so that it is possible to use substring
+               ;; completion and we can rely on completion to fix
+               ;; capitalization thanks to completion-ignore-case.
+               (beancount-inside-transaction-p))
+          (setq beancount-accounts nil)
+          (list (match-beginning 1) (match-end 1) #'beancount-account-completion-table)))))))
 
 (defun beancount-collect (regexp n)
   "Return an unique list of REGEXP group N in the current buffer."

--- a/beancount.el
+++ b/beancount.el
@@ -571,9 +571,12 @@ With an argument move to the next non cleared transaction."
           (goto-char (point-min))
           (while (re-search-forward regexp nil t)
             ;; Ignore matches around `pos' (the point position when
-            ;; entering this funcyion) since that's presumably what
+            ;; entering this function) since that's presumably what
             ;; we're currently trying to complete.
-            (unless (<= (match-beginning 0) pos (match-end 0))
+            ;; Also ignore matches inside strings (Consider: allow
+            ;; caller to specify this behavior).
+            (unless (or (<= (match-beginning 0) pos (match-end 0))
+                        (beancount-inside-string-p))
               (puthash (match-string-no-properties n) nil hash)))
           (hash-table-keys hash))))))
 

--- a/beancount.el
+++ b/beancount.el
@@ -457,8 +457,7 @@ With an argument move to the next non cleared transaction."
         (cond
          ;; non timestamped directive
          ((beancount-looking-at "[a-z]*" 0 pos)
-          (list (match-beginning 0) (match-end 0)
-                (mapcar (lambda (s) (concat s " ")) beancount-directive-names)))
+          (list (match-beginning 0) (match-end 0) beancount-directive-names))
 
          ;; poptag
          ((beancount-looking-at
@@ -468,15 +467,14 @@ With an argument move to the next non cleared transaction."
 
          ;; option
          ((beancount-looking-at
-           (concat "^option\\s-+\\(\"[a-z_]*\\)") 1 pos)
+           (concat "^option\\s-+\\(\\(?:\"[a-z_]*\"?\\)?\\)") 1 pos)
           (list (match-beginning 1) (match-end 1)
-                (mapcar (lambda (s) (concat "\"" s "\" ")) beancount-option-names)))
+                (mapcar (lambda (s) (concat "\"" s "\"")) beancount-option-names)))
 
          ;; timestamped directive
          ((beancount-looking-at
            (concat beancount-date-regexp "\\s-+\\([[:alpha:]]*\\)") 1 pos)
-          (list (match-beginning 1) (match-end 1)
-                (mapcar (lambda (s) (concat s " ")) beancount-timestamped-directive-names)))
+          (list (match-beginning 1) (match-end 1) beancount-timestamped-directive-names))
 
          ;; timestamped directives followed by account
          ((beancount-looking-at

--- a/beancount.el
+++ b/beancount.el
@@ -178,6 +178,9 @@ from the open directive for the relevant account."
 (defconst beancount-date-regexp "[0-9]\\{4\\}[-/][0-9]\\{2\\}[-/][0-9]\\{2\\}"
   "A regular expression to match dates.")
 
+(defconst beancount-timestamp-indent-regexp
+  (concat "\\s-*" beancount-date-regexp))
+
 (defconst beancount-account-regexp
   (concat (regexp-opt beancount-account-categories)
           "\\(?::[[:upper:]][[:alnum:]-_]+\\)+")
@@ -205,8 +208,14 @@ from the open directive for the relevant account."
           "\\(?:\\s-+\\(\\(" beancount-number-regexp "\\)"
           "\\s-+\\(" beancount-currency-regexp "\\)\\)\\)?"))
 
+(defconst beancount-directive-base-regexp
+  (concat "\\(" (regexp-opt beancount-directive-names) "\\) +"))
+
 (defconst beancount-directive-regexp
-  (concat "^\\(" (regexp-opt beancount-directive-names) "\\) +"))
+  (concat "^" beancount-directive-base-regexp))
+
+(defconst beancount-directive-indent-regexp
+  (concat "\\s-*" beancount-directive-base-regexp))
 
 (defconst beancount-timestamped-directive-regexp
   (concat "^\\(" beancount-date-regexp "\\) +"
@@ -527,8 +536,12 @@ will allow to align all numbers."
   (save-excursion
     (beginning-of-line)
     (cond
-     ;; Only timestamped directives start with a digit.
-     ((looking-at-p "[0-9]") 0)
+     ;; Lines which begin with a timestamp or a non-timestamped
+     ;; directive get indented to the beginning of the line.
+     ;; Consider: use "\\s-*[0-9]" instead of full timestamp regexp
+     ((or (looking-at-p beancount-timestamp-indent-regexp)
+          (looking-at-p beancount-directive-indent-regexp))
+      0)
      ;; Otherwise look at the previous line.
      ((and (= (forward-line -1) 0)
            (or (looking-at-p "[ \t].+")

--- a/beancount.el
+++ b/beancount.el
@@ -33,6 +33,7 @@
 (autoload 'ido-completing-read "ido")
 (require 'subr-x)
 (require 'outline)
+(require 'org) ;; for org-level-x faces
 (require 'thingatpt)
 (require 'imenu)
 

--- a/beancount.el
+++ b/beancount.el
@@ -490,12 +490,14 @@ With an argument move to the next non cleared transaction."
          ;; that begin with something that looks like a
          ;; non-timestamped directive--don't match the beginning of
          ;; complete transactions)
-         ((beancount-looking-at "\\($\\|[a-z]+\\)" 0 pos)
+         ((and (not (beancount-inside-string-p))
+               (beancount-looking-at "\\($\\|[a-z]+\\)" 0 pos))
           (list (match-beginning 0) (match-end 0) beancount-directive-names))
 
          ;; poptag
-         ((beancount-looking-at
-           (concat "poptag\\s-+\\(\\(?:#[" beancount-tag-chars "]*\\)\\)") 1 pos)
+         ((and (not (beancount-inside-string-p))
+               (beancount-looking-at
+                (concat "poptag\\s-+\\(\\(?:#[" beancount-tag-chars "]*\\)\\)") 1 pos))
           (list (match-beginning 1) (match-end 1)
                 (beancount-collect-pushed-tags (point-min) (point))))
 
@@ -506,15 +508,17 @@ With an argument move to the next non cleared transaction."
                 (mapcar (lambda (s) (concat "\"" s "\"")) beancount-option-names)))
 
          ;; timestamped directive
-         ((beancount-looking-at
-           (concat beancount-date-regexp "\\s-+\\([[:alpha:]]*\\)") 1 pos)
+         ((and (not (beancount-inside-string-p))
+               (beancount-looking-at
+                (concat beancount-date-regexp "\\s-+\\([[:alpha:]]*\\)") 1 pos))
           (list (match-beginning 1) (match-end 1) beancount-timestamped-directive-names))
 
          ;; timestamped directives followed by account
-         ((beancount-looking-at
-           (concat "^" beancount-date-regexp
-                   "\\s-+" (regexp-opt beancount-account-directive-names)
-                   "\\s-+\\([" beancount-account-chars "]*\\)") 1 pos)
+         ((and (not (beancount-inside-string-p))
+               (beancount-looking-at
+                (concat "^" beancount-date-regexp
+                        "\\s-+" (regexp-opt beancount-account-directive-names)
+                        "\\s-+\\([" beancount-account-chars "]*\\)") 1 pos))
           (setq beancount-accounts nil)
           (list (match-beginning 1) (match-end 1) #'beancount-account-completion-table))
 
@@ -547,7 +551,8 @@ With an argument move to the next non cleared transaction."
             (list (match-beginning 0) (match-end 0) completion-table)))
 
          ;; posting
-         ((and (beancount-looking-at
+         ((and (not (beancount-inside-string-p))
+               (beancount-looking-at
                 (concat "[ \t]+\\([" beancount-account-chars "]*\\)") 1 pos)
                ;; Do not force the account name to start with a
                ;; capital, so that it is possible to use substring

--- a/beancount.el
+++ b/beancount.el
@@ -34,6 +34,7 @@
 (require 'subr-x)
 (require 'outline)
 (require 'thingatpt)
+(require 'imenu)
 
 (defgroup beancount ()
   "Editing mode for Beancount files."

--- a/beancount.el
+++ b/beancount.el
@@ -455,8 +455,11 @@ With an argument move to the next non cleared transaction."
       (let ((pos (point)))
         (beginning-of-line)
         (cond
-         ;; non timestamped directive
-         ((beancount-looking-at "[a-z]*" 0 pos)
+         ;; non timestamped directive (only match empty lines or lines
+         ;; that begin with something that looks like a
+         ;; non-timestamped directive--don't match the beginning of
+         ;; complete transactions)
+         ((beancount-looking-at "\\($\\|[a-z]+\\)" 0 pos)
           (list (match-beginning 0) (match-end 0) beancount-directive-names))
 
          ;; poptag


### PR DESCRIPTION
This contains various improvements to the indentation/alignment and
completion systems.

There are some things that I left in place but were obsoleted and
could potentially be removed (e.g. `beancount-indent-transaction` has
been superseded by the more general `beancount-indent-directive`) or for
which I added an option to change existing behavior but we could
potentially just only use the new behavior for (e.g. always aligning
numbers when indenting a line via `beancount-tab-dwim`--I'm not sure
why one *wouldn't* want to align numbers while indenting just in this
one case).

Another thing to note is that the new indentation logic assumes that
the only lines which (after potential leading whitespace) begin with a
timestamp are timestamped directives, so if/when postings with
timestamps are added to beancount this logic will need to be updated.

In general, there are a number of behavior decisions that I made that
may warrant discussion.

This probably could be broken up into multiple smaller PRs, so I can
resubmit as such if you'd like.

I'll also mention that, while I'm not new to programming in general,
I'm a complete novice at elisp, so I may have accidentally done some
non-canonical things or not followed standard elisp conventions/best
practices.

Thank you,
Alex
