### PR TITLE
Fix a small font lock bug 

### DIFF
--- a/beancount-tests.el
+++ b/beancount-tests.el
@@ -129,6 +129,15 @@ Return a list of substrings each followed by its face."
      "1.00 USD"         beancount-amount
      "Assets:Checking"  beancount-account)))
 
+(ert-deftest beancount/fontify-005 ()
+  :tags '(font regress)
+  (beancount-test-font-lock "
+2019-01-01 open Assets:TD:TDB900 TDB900
+"
+   '("2019-01-01"       beancount-date
+     "open"             beancount-directive
+     "Assets:TD:TDB900" beancount-account)))
+
 (ert-deftest beancount/indent-001 ()
   :tags '(indent regress)
   (with-temp-buffer

--- a/beancount.el
+++ b/beancount.el
@@ -258,10 +258,10 @@ from the open directive for the relevant account."
     ;; Tags and links.
     (,(concat "\\#[" beancount-tag-chars "]*") . 'beancount-tag)
     (,(concat "\\^[" beancount-tag-chars "]*") . 'beancount-link)
-    ;; Number followed by currency not covered by previous rules.
-    (,(concat beancount-number-regexp "\\s-+" beancount-currency-regexp) . 'beancount-amount)
     ;; Accounts not covered by previous rules.
     (,beancount-account-regexp . 'beancount-account)
+    ;; Number followed by currency not covered by previous rules.
+    (,(concat beancount-number-regexp "\\s-+" beancount-currency-regexp) . 'beancount-amount)
     ))
 
 (defun beancount-tab-dwim (&optional arg)


### PR DESCRIPTION
I came across this super peculiar edge case in syntax highlighting

When an account is opened, if the account 
a) ends with a number, and 
b) is followed by a currency constraint
The number & currency part will be misinterpreted as an amount, which will then cause the account part to be misidentified. 

The fix seems to be simple... This PR reverses the order of amount & account in the font lock keywords. 
I couldn't think of an edge case that this'll break... (since account is always space-less and self-contained)
But then.. I'm new to beancount, so plz take that with a grain of salt. 