### PR TITLE
Change sign of prefix argument for `beancount-insert-date`

### DIFF
--- a/beancount.el
+++ b/beancount.el
@@ -838,14 +838,14 @@ what that column is and returns it (an integer)."
               (insert " " currency))))))))
 
 (defun beancount-insert-date (&optional days)
-  "Start a new timestamped directive with date shifted by DAYS from today."
+  "Start a new timestamped directive with date DAYS before today."
   (interactive "P")
   (unless (bolp) (newline))
   (insert (beancount--shift-current-date days) " "))
 
 (defun beancount--shift-current-date (days)
-  "Return ISO-8601 formatted date shifted by DAYS from today."
-  (let ((days-to-shift (or days 0)))
+  "Return ISO-8601 formatted date DAYS before today."
+  (let ((days-to-shift (- (or days 0))))
     (format-time-string
      "%Y-%m-%d"
      (time-add (current-time) (days-to-time days-to-shift)))))


### PR DESCRIPTION
New behaviour:
`C-u 1 M-RET` inserts a date 1 day in the *past*.
`C-u 7 M-RET` inserts a date 1 week in the *past*. 
`C-u -1 M-RET` inserts a date 1 week in *future*.

I don't think I've ever added a future transaction. Mostly, when I use a prefix arg, it's to enter a date in the past.

This new default is more convenient.