### PR TITLE
Fix a bug where `beancount-accounts` was read from the minibuffer

### DIFF
--- a/beancount.el
+++ b/beancount.el
@@ -573,10 +573,13 @@ With an argument move to the previous non cleared transaction."
 
 (defun beancount-account-completion-table (string pred action)
   (if (eq action 'metadata) '(metadata (category . beancount-account))
-    (if (null beancount-accounts)
-        (setq beancount-accounts
-              (sort (beancount-collect beancount-account-regexp 0) #'string<)))
-    (complete-with-action action beancount-accounts string pred)))
+    (with-current-buffer (let ((win (minibuffer-selected-window)))
+                           (if (window-live-p win) (window-buffer win)
+                             (current-buffer)))
+      (if (null beancount-accounts)
+          (setq beancount-accounts
+		(sort (beancount-collect beancount-account-regexp 0) #'string<)))
+      (complete-with-action action beancount-accounts string pred))))
 
 ;; Default to substring completion for beancount accounts.
 (defconst beancount--completion-overrides


### PR DESCRIPTION
Based on `completion-table-dynamic`, this sets the current buffer to the beancount buffer when doing completion in the minibuffer so the buffer-local `beancount-accounts` can be read. Without this change `beancount-insert-account` didn't display completion candidates (I'm using vertico as the completion UI).

Given the completion-at-point functions throw away `beancount-accounts` each time it might make sense to get rid of this buffer local altogether and just calculate it each time in the completion table function.

Thanks for maintaining beancount-mode!