### PR TITLE
Update account name regex to allow starting with a number

### DIFF
--- a/beancount.el
+++ b/beancount.el
@@ -213,7 +213,7 @@ from the open directive for the relevant account."
 
 (defconst beancount-account-regexp
   (concat (regexp-opt beancount-account-categories)
-          "\\(?::[[:upper:]][[:alnum:]-_]+\\)+")
+          "\\(?::[[:upper:][:digit:]][[:alnum:]-_]+\\)+")
   "A regular expression to match account names.")
 
 (defconst beancount-number-regexp "[-+]?[0-9]+\\(?:,[0-9]\\{3\\}\\)*\\(?:\\.[0-9]*\\)?"


### PR DESCRIPTION
The beancount language specification states that:

> Each component of the account names begin with a capital letter or a number and are followed by letters, numbers or dash (-) characters. All other characters are disallowed.

https://beancount.github.io/docs/beancount_language_syntax.html#accounts

The existing expression only supported accounts starting with capital letters.