### PR TITLE
fix: do not inherit from prog-mode

### DIFF
--- a/beancount.el
+++ b/beancount.el
@@ -87,7 +87,7 @@ from the open directive for the relevant account."
   "Face for Beancount account names.")
 
 (defface beancount-amount
-  '((t :inherit font-lock-default-face))
+  '((t :inherit font-lock-number-face))
   "Face for Beancount amounts.")
 
 (defface beancount-narrative
@@ -367,7 +367,7 @@ are reserved for the mode anyway.)")
     st))
 
 ;;;###autoload
-(define-derived-mode beancount-mode prog-mode "Beancount"
+(define-derived-mode beancount-mode text-mode "Beancount"
   "A mode for Beancount files.
 
 \\{beancount-mode-map}"


### PR DESCRIPTION
prog-mode ~~is overwriting~~ seems to be interfering with the font lock rules in a way that does not treat comma-delimited numbers well.  text-mode ~~provides~~ seems to provide more of a blank slate to work from.

Also, use font-lock-number-face to highlight amounts.

Partially reverts #31 

## Before

![worse](https://github.com/beancount/beancount-mode/assets/1087165/196c695a-c212-4f09-a815-3ac7bf8c4cdb)

## After

![asdf](https://github.com/beancount/beancount-mode/assets/1087165/8846d9a1-18f3-4080-bbb4-ee4b309a7c25)


Related: #29 
