### PR TITLE
Provide functions for shifting date on the current line

### DIFF
--- a/beancount-tests.el
+++ b/beancount-tests.el
@@ -332,3 +332,19 @@ known option nmaes."
     (insert "foo ^link baz")
     (goto-char 7)
     (should (equal (thing-at-point 'beancount-link) "^link"))))
+
+(ert-deftest beancount/date-shift-up-day ()
+    :tags '(date-shift)
+    (with-temp-buffer
+      (insert "2024-05-11\n")
+      (goto-char 0)
+      (beancount-date-up-day)
+      (should (equal (thing-at-point 'line) "2024-05-12\n"))))
+
+(ert-deftest beancount/date-shift-down-day ()
+    :tags '(date-shift)
+    (with-temp-buffer
+      (insert "2024-05-11\n")
+      (goto-char 0)
+      (beancount-date-down-day)
+      (should (equal (thing-at-point 'line) "2024-05-10\n"))))


### PR DESCRIPTION
Thank you for the amazing mode! It has almost everything I need to work with .beancount files.

One thing I was missing from org-mode is an ability to quickly shift transaction dates by date. The functions suggested (complete with unit tests) provide the functionality. 

Happy to tweak a bit if maintainers feel that something is missing.