### PR TITLE
Xref backend for beancount-mode

### DIFF
--- a/beancount-tests.el
+++ b/beancount-tests.el
@@ -333,18 +333,20 @@ known option nmaes."
     (goto-char 7)
     (should (equal (thing-at-point 'beancount-link) "^link"))))
 
+;;; Date shifting
+
 (ert-deftest beancount/date-shift-up-day ()
-    :tags '(date-shift)
-    (with-temp-buffer
-      (insert "2024-05-11\n")
-      (goto-char 0)
-      (beancount-date-up-day)
-      (should (equal (thing-at-point 'line) "2024-05-12\n"))))
+  :tags '(date-shift)
+  (with-temp-buffer
+    (insert "2024-05-11\n")
+    (goto-char 0)
+    (beancount-date-up-day)
+    (should (equal (thing-at-point 'line) "2024-05-12\n"))))
 
 (ert-deftest beancount/date-shift-down-day ()
-    :tags '(date-shift)
-    (with-temp-buffer
-      (insert "2024-05-11\n")
-      (goto-char 0)
-      (beancount-date-down-day)
-      (should (equal (thing-at-point 'line) "2024-05-10\n"))))
+  :tags '(date-shift)
+  (with-temp-buffer
+    (insert "2024-05-11\n")
+    (goto-char 0)
+    (beancount-date-down-day)
+    (should (equal (thing-at-point 'line) "2024-05-10\n"))))


### PR DESCRIPTION
Hello again, 

I've added another quality-of-life improvement I felt was both useful and easy enough to implement: an Xref backend. This adds support for:

1. Jumping up account definitions (aka open directive) under point using the default =M-.= binding
2. finding account under point references using =M-?=.
3. grepping through known symbol references and definitions using apropos like search with =C-M-.=.

While it is not hard to use basic tools such as grep with Beancount files, I felt that working from standard tooling aligns well with other modes supporting Xref and would be helpful to people used to default keybindings. 

I checked it in Emacs 26, 27, 28, 29. It was not without some complications (a backported function) but should work everywhere out of the box.

Let me know if something needs tweaking.

Thanks!