### PR TITLE
Fixes in completion and interactive specs

### DIFF
--- a/beancount.el
+++ b/beancount.el
@@ -940,13 +940,13 @@ Emacs-26 is dropped."
 (defun beancount-date-up-day (&optional days)
   "Increase the date in the current line by one day.
 With prefix ARG, change that many days."
-  (interactive "p" beancount-mode)
+  (interactive "p")
   (beancount--shift-date-at-point (or days 1)))
 
 (defun beancount-date-down-day (&optional days)
   "Decrease the date in the current line by one day.
 With prefix ARG, change that many days."
-  (interactive "p" beancount-mode)
+  (interactive "p")
   (beancount--shift-date-at-point (- (or days 1))))
 
 (defvar beancount-install-dir nil

--- a/beancount.el
+++ b/beancount.el
@@ -561,7 +561,7 @@ With an argument move to the previous non cleared transaction."
                   (lambda (string pred action)
                     (if (null candidates)
                         (setq candidates
-                              (sort (beancount-collect regexp 1) #'string<)))
+                              (sort (beancount-collect-unique regexp 1) #'string<)))
                     (complete-with-action action candidates string pred))))
             (list (match-beginning 1) (match-end 1) completion-table)))
 
@@ -574,7 +574,7 @@ With an argument move to the previous non cleared transaction."
                   (lambda (string pred action)
                     (if (null candidates)
                         (setq candidates
-                              (sort (beancount-collect regexp 1) #'string<)))
+                              (sort (beancount-collect-unique regexp 1) #'string<)))
                     (complete-with-action action candidates string pred))))
             (list (match-beginning 1) (match-end 1) completion-table))))))))
 


### PR DESCRIPTION
Fixes extrated from #51:

1. Fix completion by using new functions.
2. Silence the compiler on 26.1 by fixing the interactive spec.

I feel that the completion-at-point logic is too fragile and needs more unit tests.

Thanks!