### PR TITLE
Fix beancount-transaction-regexp not recognizing 'txn' directive

### DIFF
--- a/beancount.el
+++ b/beancount.el
@@ -238,8 +238,7 @@ _not_ followed by an account.")
 
 (defconst beancount-transaction-regexp
   (concat "^\\(" beancount-date-regexp "\\) +"
-          "\\(?:txn +\\)?"
-          "\\(" beancount-flag-regexp "\\) +"
+          "\\(\\(?:txn+\\)\\|" beancount-flag-regexp "\\) +"
           "\\(\".*\"\\)"))
 
 (defconst beancount-posting-regexp


### PR DESCRIPTION
The docs say 'txn' OR flag.  Also, 'beancount-flag-regexp' is a single character, thus does not need a shy group enclosing it.

Test case (put point in here and eval `(looking-at-p beancount-transaction-regexp)`:

```
;; 016. Payee with narration and 'txn' directive
2024-07-28 txn "Acme" "widgets"
  Assets:Bank:Checking                 -10.00 USD
  Expenses:Whatever
```

I came across this while making tests for my own (soon to be released) txn parser.

I guess I could/should get some together for here, too.

FWIW, I did pass all existing tests locally before submitting.