### PR TITLE
Fix the output expected from Fava on startup

### DIFF
--- a/beancount.el
+++ b/beancount.el
@@ -1262,21 +1262,21 @@ Essentially a much simplified version of `next-line'."
 (defun beancount-fava ()
   "Start (and open) or stop the fava server."
   (interactive)
-  (if beancount--fava-process
-      (progn
-        (delete-process beancount--fava-process)
-        (setq beancount--fava-process nil)
-        (message "Fava process killed"))
-    (setq beancount--fava-process
-          (start-process "fava" (get-buffer-create "*fava*") "fava"
-                         (if (eq 'beancount-mode major-mode) (buffer-file-name)
-                           (read-file-name "File to load: "))))
-    (set-process-filter beancount--fava-process #'beancount--fava-filter)
-    (message "Fava process started")))
+  (when beancount--fava-process
+    (delete-process beancount--fava-process)
+    (setq beancount--fava-process nil)
+    (message "Fava process killed"))
+  (setq beancount--fava-process
+        (start-process "fava" (get-buffer-create "*fava*") "fava"
+                       (if (eq 'beancount-mode major-mode) (buffer-file-name)
+                         (read-file-name "File to load: "))))
+  (set-process-filter beancount--fava-process #'beancount--fava-filter)
+  (message "Fava process started"))
 
 (defun beancount--fava-filter (_process output)
   "Open fava url as soon as the address is announced."
-  (if-let ((url (string-match "Running Fava on \\(http://.+:[0-9]+\\)\n" output)))
+  (with-current-buffer "*fava*" (insert output))
+  (if-let ((url (string-match "Starting Fava on \\(http://.+:[0-9]+\\)\n" output)))
       (browse-url (match-string 1 output))))
 
 ;;; Xref backend


### PR DESCRIPTION
Fava outputs "Starting Fava on ..." instead of "Running Fava on ..." since [this commit][1].

Also, if the Fava process was already running, `beancount-fava` would just kill it. Now it will kill it and try to start a new one.

[1]: https://github.com/beancount/fava/commit/8bb3994af39d682e891e2576c6bf6ddfc074b28d