### PR TITLE
Allow single-letter subaccount names. Ignore Emacs backup files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 *.elc
 /beancount-autoloads.el
 /beancount-pkg.el

--- a/beancount.el
+++ b/beancount.el
@@ -223,7 +223,7 @@ _not_ followed by an account.")
 
 (defconst beancount-account-regexp
   (concat (regexp-opt beancount-account-categories)
-          "\\(?::[[:upper:][:digit:]][[:alnum:]-_]+\\)+")
+          "\\(?::[[:upper:][:digit:]][[:alnum:]-_]*\\)+")
   "A regular expression to match account names.")
 
 (defconst beancount-number-regexp "[-+]?[0-9]+\\(?:,[0-9]\\{3\\}\\)*\\(?:\\.[0-9]*\\)?"


### PR DESCRIPTION
Single letter subaccount names like `Expenses:Houses:A:Taxes` are supported by beancount and should be supported in `beancount-mode`.

Resolves [Issue #60 ](https://github.com/beancount/beancount-mode/issues/60)