### PR TITLE
Remove unnecessary '+' after 'txn' in beancount-transaction-regexp

### DIFF
--- a/beancount.el
+++ b/beancount.el
@@ -239,7 +239,7 @@ _not_ followed by an account.")
 
 (defconst beancount-transaction-regexp
   (concat "^\\(" beancount-date-regexp "\\) +"
-          "\\(\\(?:txn+\\)\\|" beancount-flag-regexp "\\) +"
+          "\\(\\(?:txn\\)\\|" beancount-flag-regexp "\\) +"
           "\\(\".*\"\\)"))
 
 (defconst beancount-posting-regexp


### PR DESCRIPTION
This is in response to dnicolodi comment on my last PR (56) back on 2024-08-05 (which I did not notice until now, apologies).

I tested locally several variations by putting point on a txn and executing (looking-at beancount-transaction-regexp).