### PR TITLE
Add customizable account-type root names

### DIFF
--- a/beancount-tests.el
+++ b/beancount-tests.el
@@ -183,6 +183,20 @@ ACCOUNTS = (assets liabilities equity income expenses)"
     (should (equal beancount-account-categories
                    '("Actif" "Passività" "Собственный-капитал" "Ingresos" "Koszty")))))
 
+(ert-deftest beancount/account-customization-regexps ()
+  :tags '(account customization regexp regress)
+  (beancount-with-custom-accounts ("Actif" "Passività" "Собственный-капитал" "Ingresos" "Koszty")
+    (should (string-match beancount-account-regexp
+                          "Actif:Foo"))
+    (should (string-match beancount-posting-regexp
+                          "  Passività:Foo 1.00 EUR"))
+    (should (string-match beancount-balance-regexp
+                          "2026-01-01 balance Собственный-капитал:Foo 100.00 RUB"))
+    (should (string-match beancount-open-directive-regexp
+                          "2026-01-01 open Ingresos:Foo"))
+    (should (string-match beancount-xref-symbol-regexp
+                          "Koszty:Bar"))))
+
 (ert-deftest beancount/indent-001 ()
   :tags '(indent regress)
   (with-temp-buffer
@@ -241,6 +255,141 @@ known option nmaes."
   Expenses:Test
 "))
     (should (equal beancount-accounts '("Assets:Checking" "Expenses:Test")))))
+
+(ert-deftest beancount/completion-custom-accounts-french ()
+  "Verify beancount-mode auto-completes accounts with French root names."
+  :tags '(completion customization regress)
+  (beancount-with-custom-accounts ("Actif" "Passif" "Capitaux-propres" "Produits" "Charges")
+    (with-temp-buffer
+      (insert "
+2026-01-01 * \"Example\"
+  Charges:Test    1.00 EUR
+  Actif:Checking
+
+2026-01-01 * \"Example\"
+  Charges:T
+")
+      (beancount-mode)
+      (forward-line -1)
+      (move-end-of-line 1)
+      (completion-at-point)
+      (should (equal (buffer-string) "
+2026-01-01 * \"Example\"
+  Charges:Test    1.00 EUR
+  Actif:Checking
+
+2026-01-01 * \"Example\"
+  Charges:Test
+"))
+      (should (equal beancount-accounts '("Actif:Checking" "Charges:Test"))))))
+
+(ert-deftest beancount/completion-custom-accounts-italian ()
+  "Verify beancount-mode auto-completes accounts with Italian root names."
+  :tags '(completion customization regress)
+  (beancount-with-custom-accounts ("Attività" "Passività" "Patrimonio-netto" "Ricavi" "Costi")
+    (with-temp-buffer
+      (insert "
+2026-01-01 * \"Example\"
+  Costi:Test    1.00 EUR
+  Attività:Checking
+
+2026-01-01 * \"Example\"
+  Costi:T
+")
+      (beancount-mode)
+      (forward-line -1)
+      (move-end-of-line 1)
+      (completion-at-point)
+      (should (equal (buffer-string) "
+2026-01-01 * \"Example\"
+  Costi:Test    1.00 EUR
+  Attività:Checking
+
+2026-01-01 * \"Example\"
+  Costi:Test
+"))
+      (should (equal beancount-accounts '("Attività:Checking" "Costi:Test"))))))
+
+(ert-deftest beancount/completion-custom-accounts-russian ()
+  "Verify beancount-mode auto-completes accounts with Russian root names."
+  :tags '(completion customization regress)
+  (beancount-with-custom-accounts ("Активы" "Обязательства" "Собственный-капитал" "Доходы" "Расходы")
+    (with-temp-buffer
+      (insert "
+2026-01-01 * \"Example\"
+  Расходы:Test    1.00 RUB
+  Активы:Checking
+
+2026-01-01 * \"Example\"
+  Расходы:T
+")
+      (beancount-mode)
+      (forward-line -1)
+      (move-end-of-line 1)
+      (completion-at-point)
+      (should (equal (buffer-string) "
+2026-01-01 * \"Example\"
+  Расходы:Test    1.00 RUB
+  Активы:Checking
+
+2026-01-01 * \"Example\"
+  Расходы:Test
+"))
+      (should (equal beancount-accounts '("Активы:Checking" "Расходы:Test"))))))
+
+(ert-deftest beancount/completion-custom-accounts-spanish ()
+  "Verify beancount-mode auto-completes accounts with Spanish root names."
+  :tags '(completion customization regress)
+  (beancount-with-custom-accounts ("Activos" "Pasivos" "Patrimonio-neto" "Ingresos" "Gastos")
+    (with-temp-buffer
+      (insert "
+2026-01-01 * \"Example\"
+  Gastos:Test    1.00 EUR
+  Activos:Checking
+
+2026-01-01 * \"Example\"
+  Gastos:T
+")
+      (beancount-mode)
+      (forward-line -1)
+      (move-end-of-line 1)
+      (completion-at-point)
+      (should (equal (buffer-string) "
+2026-01-01 * \"Example\"
+  Gastos:Test    1.00 EUR
+  Activos:Checking
+
+2026-01-01 * \"Example\"
+  Gastos:Test
+"))
+      (should (equal beancount-accounts '("Activos:Checking" "Gastos:Test"))))))
+
+(ert-deftest beancount/completion-custom-accounts-polish ()
+  "Verify beancount-mode auto-completes accounts with Polish root names."
+  :tags '(completion customization regress)
+  (beancount-with-custom-accounts ("Aktywa" "Pasywa" "Kapitał-własny" "Przychody" "Koszty")
+    (with-temp-buffer
+      (insert "
+2026-01-01 * \"Example\"
+  Koszty:Test    1.00 PLN
+  Aktywa:Checking
+
+2026-01-01 * \"Example\"
+  Koszty:T
+")
+      (beancount-mode)
+      (forward-line -1)
+      (move-end-of-line 1)
+      (completion-at-point)
+      (should (equal (buffer-string) "
+2026-01-01 * \"Example\"
+  Koszty:Test    1.00 PLN
+  Aktywa:Checking
+
+2026-01-01 * \"Example\"
+  Koszty:Test
+"))
+      (should (equal beancount-accounts '("Aktywa:Checking" "Koszty:Test"))))))
 
 (ert-deftest beancount/outline-001 ()
   :tags '(outline)

--- a/beancount-tests.el
+++ b/beancount-tests.el
@@ -140,6 +140,49 @@ Return a list of substrings each followed by its face."
      "open"             beancount-directive
      "Assets:TD:TDB900" beancount-account)))
 
+;; Account-type customization
+
+(defun beancount-set-account-categories (assets liabilities equity income expenses)
+  "Set account defcustoms and trigger `:set' rebuilds via
+`customize-set-variable'."
+  (customize-set-variable 'beancount-assets assets)
+  (customize-set-variable 'beancount-liabilities liabilities)
+  (customize-set-variable 'beancount-equity equity)
+  (customize-set-variable 'beancount-income income)
+  (customize-set-variable 'beancount-expenses expenses))
+
+(defun beancount-reset-account-categories ()
+  "Reset account defcustoms to `:init-value' and trigger `:set' rebuilds via
+`custom-reevaluate-setting'."
+  (custom-reevaluate-setting 'beancount-assets)
+  (custom-reevaluate-setting 'beancount-liabilities)
+  (custom-reevaluate-setting 'beancount-equity)
+  (custom-reevaluate-setting 'beancount-income)
+  (custom-reevaluate-setting 'beancount-expenses))
+
+(defmacro beancount-with-custom-accounts (accounts &rest body)
+  "Set account categories to CATEGORIES, run BODY, then reset to default values.
+ACCOUNTS = (assets liabilities equity income expenses)"
+  (declare (indent 1))
+  `(unwind-protect
+       (progn
+         (beancount-set-account-categories ,@accounts)
+         ,@body)
+     (beancount-reset-account-categories)))
+
+(ert-deftest beancount/account-categories-defaults ()
+  "Test that beancount-account-categories uses default values."
+  :tags '(account customization regress)
+  (should (equal beancount-account-categories
+                 '("Assets" "Liabilities" "Equity" "Income" "Expenses"))))
+
+(ert-deftest beancount/account-categories-custom ()
+  "Test that beancount-account-categories respects custom variable values."
+  :tags '(account customization regress)
+  (beancount-with-custom-accounts ("資産" "التزامات" "Собственный капитал" "收入" "Despesas")
+    (should (equal beancount-account-categories
+                   '("資産" "التزامات" "Собственный капитал" "收入" "Despesas")))))
+
 (ert-deftest beancount/indent-001 ()
   :tags '(indent regress)
   (with-temp-buffer

--- a/beancount-tests.el
+++ b/beancount-tests.el
@@ -179,9 +179,9 @@ ACCOUNTS = (assets liabilities equity income expenses)"
 (ert-deftest beancount/account-categories-custom ()
   "Test that beancount-account-categories respects custom variable values."
   :tags '(account customization regress)
-  (beancount-with-custom-accounts ("資産" "التزامات" "Собственный капитал" "收入" "Despesas")
+  (beancount-with-custom-accounts ("Actif" "Passività" "Собственный-капитал" "Ingresos" "Koszty")
     (should (equal beancount-account-categories
-                   '("資産" "التزامات" "Собственный капитал" "收入" "Despesas")))))
+                   '("Actif" "Passività" "Собственный-капитал" "Ingresos" "Koszty")))))
 
 (ert-deftest beancount/indent-001 ()
   :tags '(indent regress)

--- a/beancount.el
+++ b/beancount.el
@@ -70,10 +70,133 @@ complete the posting at point. The correct currency is determined
 from the open directive for the relevant account."
   :type 'boolean)
 
+;;; Account-type customization.
+
+;; Parsing primitives
+
+(defconst beancount-date-regexp "[0-9]\\{4\\}[-/][0-9]\\{2\\}[-/][0-9]\\{2\\}"
+  "A regular expression to match dates.")
+
+(defconst beancount-number-regexp "[-+]?[0-9]+\\(?:,[0-9]\\{3\\}\\)*\\(?:\\.[0-9]*\\)?"
+  "A regular expression to match decimal numbers.")
+
+(defconst beancount-currency-regexp "[A-Z][A-Z-_'.]*"
+  "A regular expression to match currencies.")
+
+(defconst beancount-tag-chars "[:alnum:]-_/.")
+
+(defconst beancount-account-chars "[:alnum:]-_:")
+
+(defconst beancount-flag-regexp
+  ;; Single character: Certain symbols plus uppercase letters.
+  ;; case-fold-search t will cause a single lowercase letter to match also.
+  "[!#%&*?A-Z]")
+
+;; Directive definitions
+
+(defconst beancount-directive-names
+  '("include"
+    "option"
+    "plugin"
+    "poptag"
+    "pushtag")
+  "Directive names that can appear at the beginning of a line.")
+
+(defconst beancount-account-directive-names
+  '("balance"
+    "close"
+    "document"
+    "note"
+    "open"
+    "pad")
+  "Directive names that can appear after a date and are followd by an account.")
+
+(defconst beancount-no-account-directive-names
+  '("commodity"
+    "event"
+    "price"
+    "query"
+    "txn")
+  "Directives with a date but without an account.
+
+List of directive names that can appear after a date and that are
+_not_ followed by an account.")
+
+(defconst beancount-timestamped-directive-names
+  (append beancount-account-directive-names
+          beancount-no-account-directive-names)
+  "Directive names that can appear after a date.")
+
+;; Directive regexps
+
+(defconst beancount-directive-regexp
+  (concat "^\\(" (regexp-opt beancount-directive-names) "\\) +"))
+
+(defconst beancount-timestamped-directive-regexp
+  (concat "^\\(" beancount-date-regexp "\\) +"
+          "\\(" (regexp-opt beancount-timestamped-directive-names) "\\) +"))
+
+;; Transaction and metadata regexps
+
+(defconst beancount-transaction-regexp
+  (concat "^\\(" beancount-date-regexp "\\) +"
+          "\\(\\(?:txn\\)\\|" beancount-flag-regexp "\\) +"
+          "\\(\".*\"\\)"))
+
+(defconst beancount-metadata-regexp
+  "^\\s-+\\([a-z][A-Za-z0-9_-]+:\\)\\s-+\\(.+\\)")
+
+;; Outline minor mode regexp
+
+(defconst beancount-outline-regexp
+  "\\(;;;+\\|\\*+\\)"
+  "A regular expression to match outline section headers.
+
+This is a grouping regular expression because the subexpression is used in
+determining the outline level in `beancount-outline-level'.")
+
+;; Dynamic regexps built by `beancount--build-regexps'
+
 (defvar beancount-account-categories nil
   "List of account-type root names.
 
-Its value is set by `beancount--build-regexps'")
+Value set by `beancount--build-regexps'.")
+
+(defvar beancount-account-regexp nil
+  "A regular expression to match account names.
+
+Value set by `beancount--build-regexps'.")
+
+(defvar beancount-posting-regexp nil
+  "A regular expression to match transaction postings.
+
+Value set by `beancount--build-regexps'.")
+
+(defvar beancount-balance-regexp nil
+  "A regular expression to match balance directives.
+
+The grouping in this regular expression matches the one in
+`beancount-posting-regexp' to be used in amount align machinery.
+See `beancount-align-number'.
+
+Value set by `beancount--build-regexps'.")
+
+(defvar beancount-open-directive-regexp nil
+  "A regular expression to match open directives.
+
+Value set by `beancount--build-regexps'.")
+
+(defvar beancount-xref-symbol-regexp
+  "Regular expression for all symbols recognised by the Xref backend.
+
+Value set by `beancount--build-regexps'.")
+
+(defvar beancount-font-lock-keywords nil
+  "Keywords to be used by Emacs font-locking.
+
+Value set by `beancount--build-regexps'.")
+
+;; Group, support functions and customizable variables
 
 (defgroup beancount-account-types nil
   "Beancount account type root names."
@@ -96,8 +219,55 @@ Its value is set by `beancount--build-regexps'")
                 beancount-liabilities
                 beancount-equity
                 beancount-income
-                beancount-expenses)))
-    (setq beancount-account-categories account-categories)))
+                beancount-expenses))
+         (account-regexp
+          (concat (regexp-opt account-categories)
+                  "\\(?::[[:upper:][:digit:]][[:alnum:]-_]*\\)+"))
+         (posting-regexp
+          (concat "^\\s-+"
+                  "\\(" account-regexp "\\)"
+                  "\\(?:\\s-+\\(\\(" beancount-number-regexp "\\)"
+                  "\\s-+\\(" beancount-currency-regexp "\\)\\)\\)?"))
+         (balance-regexp
+          (concat "^" beancount-date-regexp "\\s-+balance\\s-+"
+                  "\\(" account-regexp "\\)\\s-+"
+                  "\\(\\(" beancount-number-regexp "\\)\\s-+\\(" beancount-currency-regexp "\\)\\)"))
+         (open-directive-regexp
+          (concat "^\\(" beancount-date-regexp "\\) +"
+                  "\\(open\\) +"
+                  "\\(" account-regexp "\\)"))
+         (xref-symbol-regexp
+          (rx-to-string `(or (regexp ,account-regexp)
+                             (regexp ,(concat "#[" beancount-tag-chars "]+"))
+                             (regexp ,(concat "\\^[" beancount-tag-chars "]+")))))
+         (font-lock-keywords
+          `((,beancount-transaction-regexp (1 'beancount-date)
+                                           (2 (beancount-face-by-state (match-string 2)) t)
+                                           (3 (beancount-face-by-state (match-string 2)) t))
+            (,posting-regexp (1 'beancount-account)
+                             (2 'beancount-amount nil :lax))
+            (,beancount-metadata-regexp (1 'beancount-metadata)
+                                        (2 'beancount-metadata t))
+            (,beancount-directive-regexp (1 'beancount-directive))
+            (,beancount-timestamped-directive-regexp (1 'beancount-date)
+                                                     (2 'beancount-directive))
+            ;; Fontify section headers when composed with outline-minor-mode.
+            (,(concat "^\\(" beancount-outline-regexp "\\).*") (0 (beancount-outline-face)))
+            ;; Tags and links.
+            (,(concat "\\#[" beancount-tag-chars "]*") . 'beancount-tag)
+            (,(concat "\\^[" beancount-tag-chars "]*") . 'beancount-link)
+            ;; Accounts not covered by previous rules.
+            (,account-regexp . 'beancount-account)
+            ;; Number followed by currency not covered by previous rules.
+            (,(concat beancount-number-regexp "\\s-+" beancount-currency-regexp) . 'beancount-amount)
+            )))
+    (setq beancount-account-categories account-categories)
+    (setq beancount-account-regexp account-regexp)
+    (setq beancount-posting-regexp posting-regexp)
+    (setq beancount-balance-regexp balance-regexp)
+    (setq beancount-open-directive-regexp open-directive-regexp)
+    (setq beancount-xref-symbol-regexp xref-symbol-regexp)
+    (setq beancount-font-lock-keywords font-lock-keywords)))
 
 (defcustom beancount-assets "Assets"
   "Root name for Beancount asset accounts."
@@ -209,43 +379,6 @@ Its value is set by `beancount--build-regexps'")
   '((t :inherit outline-8))
   "Outline level 8.")
 
-(defconst beancount-account-directive-names
-  '("balance"
-    "close"
-    "document"
-    "note"
-    "open"
-    "pad")
-  "Directive names that can appear after a date and are followd by an account.")
-
-(defconst beancount-no-account-directive-names
-  '("commodity"
-    "event"
-    "price"
-    "query"
-    "txn")
-  "Directives with a date but without an account.
-
-List of directive names that can appear after a date and that are
-_not_ followed by an account.")
-
-(defconst beancount-timestamped-directive-names
-  (append beancount-account-directive-names
-          beancount-no-account-directive-names)
-  "Directive names that can appear after a date.")
-
-(defconst beancount-directive-names
-  '("include"
-    "option"
-    "plugin"
-    "poptag"
-    "pushtag")
-  "Directive names that can appear at the beginning of a line.")
-
-(defconst beancount-tag-chars "[:alnum:]-_/.")
-
-(defconst beancount-account-chars "[:alnum:]-_:")
-
 (defconst beancount-option-names
   ;; This list is kept in sync with the options defined in
   ;; beancount/parser/options.py.
@@ -278,69 +411,6 @@ _not_ followed by an account.")
     "title"
     "tolerance_multiplier"))
 
-(defconst beancount-date-regexp "[0-9]\\{4\\}[-/][0-9]\\{2\\}[-/][0-9]\\{2\\}"
-  "A regular expression to match dates.")
-
-(defconst beancount-account-regexp
-  (concat (regexp-opt beancount-account-categories)
-          "\\(?::[[:upper:][:digit:]][[:alnum:]-_]*\\)+")
-  "A regular expression to match account names.")
-
-(defconst beancount-number-regexp "[-+]?[0-9]+\\(?:,[0-9]\\{3\\}\\)*\\(?:\\.[0-9]*\\)?"
-  "A regular expression to match decimal numbers.")
-
-(defconst beancount-currency-regexp "[A-Z][A-Z-_'.]*"
-  "A regular expression to match currencies.")
-
-(defconst beancount-flag-regexp
-  ;; Single character: Certain symbols plus uppercase letters.
-  ;; case-fold-search t will cause a single lowercase letter to match also.
-  "[!#%&*?A-Z]")
-
-(defconst beancount-transaction-regexp
-  (concat "^\\(" beancount-date-regexp "\\) +"
-          "\\(\\(?:txn\\)\\|" beancount-flag-regexp "\\) +"
-          "\\(\".*\"\\)"))
-
-(defconst beancount-posting-regexp
-  (concat "^\\s-+"
-          "\\(" beancount-account-regexp "\\)"
-          "\\(?:\\s-+\\(\\(" beancount-number-regexp "\\)"
-          "\\s-+\\(" beancount-currency-regexp "\\)\\)\\)?"))
-
-(defconst beancount-balance-regexp
-  ;; The grouping in this regular expression matches the one in
-  ;; `beancount-posting-regexp' to be used in amount align
-  ;; machinery. See `beancount-align-number'.
-  (concat "^" beancount-date-regexp "\\s-+balance\\s-+"
-          "\\(" beancount-account-regexp "\\)\\s-+"
-          "\\(\\(" beancount-number-regexp "\\)\\s-+\\(" beancount-currency-regexp "\\)\\)"))
-
-(defconst beancount-directive-regexp
-  (concat "^\\(" (regexp-opt beancount-directive-names) "\\) +"))
-
-(defconst beancount-timestamped-directive-regexp
-  (concat "^\\(" beancount-date-regexp "\\) +"
-          "\\(" (regexp-opt beancount-timestamped-directive-names) "\\) +"))
-
-(defconst beancount-metadata-regexp
-  "^\\s-+\\([a-z][A-Za-z0-9_-]+:\\)\\s-+\\(.+\\)")
-
-(defconst beancount-open-directive-regexp
-  (concat "^\\(" beancount-date-regexp "\\) +"
-          "\\(open\\) +"
-          "\\(" beancount-account-regexp "\\)"))
-
-;; This is a grouping regular expression because the subexpression is
-;; used in determining the outline level in `beancount-outline-level'.
-(defvar beancount-outline-regexp "\\(;;;+\\|\\*+\\)")
-
-;; Regular expression for all symbols recognised by the Xref backend.
-(defconst beancount-xref-symbol-regexp
-  (rx-to-string `(or (regexp ,beancount-account-regexp)
-                     (regexp ,(concat "#[" beancount-tag-chars "]+"))
-                     (regexp ,(concat "\\^[" beancount-tag-chars "]+")))))
-
 (defun beancount-outline-level ()
   (let ((len (- (match-end 1) (match-beginning 1))))
     (if (string-equal (substring (match-string 1) 0 1) ";")
@@ -365,28 +435,6 @@ _not_ followed by an account.")
         (8 'beancount-outline-8)
         (otherwise nil))
     nil))
-
-(defvar beancount-font-lock-keywords
-  `((,beancount-transaction-regexp (1 'beancount-date)
-                                   (2 (beancount-face-by-state (match-string 2)) t)
-                                   (3 (beancount-face-by-state (match-string 2)) t))
-    (,beancount-posting-regexp (1 'beancount-account)
-                               (2 'beancount-amount nil :lax))
-    (,beancount-metadata-regexp (1 'beancount-metadata)
-                                (2 'beancount-metadata t))
-    (,beancount-directive-regexp (1 'beancount-directive))
-    (,beancount-timestamped-directive-regexp (1 'beancount-date)
-                                             (2 'beancount-directive))
-    ;; Fontify section headers when composed with outline-minor-mode.
-    (,(concat "^\\(" beancount-outline-regexp "\\).*") (0 (beancount-outline-face)))
-    ;; Tags and links.
-    (,(concat "\\#[" beancount-tag-chars "]*") . 'beancount-tag)
-    (,(concat "\\^[" beancount-tag-chars "]*") . 'beancount-link)
-    ;; Accounts not covered by previous rules.
-    (,beancount-account-regexp . 'beancount-account)
-    ;; Number followed by currency not covered by previous rules.
-    (,(concat beancount-number-regexp "\\s-+" beancount-currency-regexp) . 'beancount-amount)
-    ))
 
 (defun beancount-tab-dwim (&optional arg)
   (interactive "P")

--- a/beancount.el
+++ b/beancount.el
@@ -70,6 +70,35 @@ complete the posting at point. The correct currency is determined
 from the open directive for the relevant account."
   :type 'boolean)
 
+(defgroup beancount-account-types nil
+  "Beancount account type root names."
+  :group 'beancount)
+
+(defcustom beancount-assets "Assets"
+  "Root name for Beancount asset accounts."
+  :type 'string
+  :group 'beancount-account-types)
+
+(defcustom beancount-liabilities "Liabilities"
+  "Root name for Beancount liabilities accounts."
+  :type 'string
+  :group 'beancount-account-types)
+
+(defcustom beancount-equity "Equity"
+  "Root name for Beancount equity accounts."
+  :type 'string
+  :group 'beancount-account-types)
+
+(defcustom beancount-income "Income"
+  "Root name for Beancount income accounts."
+  :type 'string
+  :group 'beancount-account-types)
+
+(defcustom beancount-expenses "Expenses"
+  "Root name for Beancount expenses accounts."
+  :type 'string
+  :group 'beancount-account-types)
+
 (defgroup beancount-faces nil "Beancount mode highlighting" :group 'beancount)
 
 (defface beancount-directive
@@ -182,7 +211,11 @@ _not_ followed by an account.")
   "Directive names that can appear at the beginning of a line.")
 
 (defconst beancount-account-categories
-  '("Assets" "Liabilities" "Equity" "Income" "Expenses"))
+  (list beancount-assets
+        beancount-liabilities
+        beancount-equity
+        beancount-income
+        beancount-expenses))
 
 (defconst beancount-tag-chars "[:alnum:]-_/.")
 

--- a/beancount.el
+++ b/beancount.el
@@ -70,34 +70,66 @@ complete the posting at point. The correct currency is determined
 from the open directive for the relevant account."
   :type 'boolean)
 
+(defvar beancount-account-categories nil
+  "List of account-type root names.
+
+Its value is set by `beancount--build-regexps'")
+
 (defgroup beancount-account-types nil
   "Beancount account type root names."
   :group 'beancount)
 
+(defun beancount--set-and-rebuild (symbol value)
+  "Set SYMBOL to VALUE and recompute regexps."
+  (set-default symbol value)
+  (when (cl-every #'boundp '(beancount-assets
+                             beancount-liabilities
+                             beancount-equity
+                             beancount-income
+                             beancount-expenses))
+    (beancount--build-regexps)))
+
+(defun beancount--build-regexps ()
+  "Compute account-type dependent regexps from current defcustom values."
+  (let* ((account-categories
+          (list beancount-assets
+                beancount-liabilities
+                beancount-equity
+                beancount-income
+                beancount-expenses)))
+    (setq beancount-account-categories account-categories)))
+
 (defcustom beancount-assets "Assets"
   "Root name for Beancount asset accounts."
   :type 'string
-  :group 'beancount-account-types)
+  :group 'beancount-account-types
+  :set #'beancount--set-and-rebuild)
 
 (defcustom beancount-liabilities "Liabilities"
   "Root name for Beancount liabilities accounts."
   :type 'string
-  :group 'beancount-account-types)
+  :group 'beancount-account-types
+  :set #'beancount--set-and-rebuild)
 
 (defcustom beancount-equity "Equity"
   "Root name for Beancount equity accounts."
   :type 'string
-  :group 'beancount-account-types)
+  :group 'beancount-account-types
+  :set #'beancount--set-and-rebuild)
 
 (defcustom beancount-income "Income"
   "Root name for Beancount income accounts."
   :type 'string
-  :group 'beancount-account-types)
+  :group 'beancount-account-types
+  :set #'beancount--set-and-rebuild)
 
 (defcustom beancount-expenses "Expenses"
   "Root name for Beancount expenses accounts."
   :type 'string
-  :group 'beancount-account-types)
+  :group 'beancount-account-types
+  :set #'beancount--set-and-rebuild)
+
+(beancount--build-regexps)
 
 (defgroup beancount-faces nil "Beancount mode highlighting" :group 'beancount)
 
@@ -209,13 +241,6 @@ _not_ followed by an account.")
     "poptag"
     "pushtag")
   "Directive names that can appear at the beginning of a line.")
-
-(defconst beancount-account-categories
-  (list beancount-assets
-        beancount-liabilities
-        beancount-equity
-        beancount-income
-        beancount-expenses))
 
 (defconst beancount-tag-chars "[:alnum:]-_/.")
 


### PR DESCRIPTION
Implement customizable account-type root names via the `beancount-account-types` customize group.

Although Beancount supports custom root names for account types, like so:

```beancount
option "name_equity"      "Valor-Patrimonial"
option "name_assets"      "Ativos"
option "name_liabilities" "Passivos"
option "name_income"      "Receitas"
option "name_expenses"    "Despesas"
```

... `beancount-mode` doesn't recognize them. There's some discussion about that in issue #2, and although this is not the ideal solution, as in, `beancount-mode` is not yet automatically parsing the `option` directives from the file, exposing them through Emacs' native `customize` interface make all my hackish workarounds on `init.el` obsolete.

If you use `use-package`, you can do something like this:

```emacs-lisp
(use-package beancount
  :ensure nil
  :load-path "~/.config/emacs/site-lisp/beancount-mode"
  :init
  (require 'beancount)
  :custom
  (beancount-assets "Ativos")
  (beancount-equity "Valor-Patrimonial")
  (beancount-expenses "Despesas")
  (beancount-income "Receitas")
  (beancount-liabilities "Passivos"))
```
